### PR TITLE
Add SootRad case to CI testing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,6 +83,65 @@ jobs:
       run: |
         mpirun -n 2 ./PeleLMeX3d.gnu.MPI.ex input.3d-regt amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amr.n_cell=128 32 32
 
+  # Build and Run the SootRadTest RegTest with GNU9.3 and MPI support
+  SOOTRAD:
+    name: GNU@9.3 MPI Run [SootRadTest]
+    runs-on: ubuntu-latest
+    env:
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    steps:
+    - uses: actions/checkout@v3
+    - name: System Dependencies
+      run: .github/workflows/dependencies/dependencies_gcc10.sh
+    - name: Repo Dependencies
+      run: |
+        Utils/CloneDeps.sh
+        cd ${GITHUB_WORKSPACE}/build/amrex
+        git remote add wzhang https://github.com/WeiqunZhang/amrex.git
+        git fetch wzhang eb_robin
+        git checkout eb_robin
+        cd -
+        git clone --branch main https://github.com/AMReX-Combustion/PeleRad.git build/PeleRad
+    - name: Build Release
+      env:
+         AMREX_HOME: ${GITHUB_WORKSPACE}/build/amrex
+         PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
+         PELERAD_HOME: ${GITHUB_WORKSPACE}/build/PeleRad
+         PELEMP_HOME: ${GITHUB_WORKSPACE}/build/PeleMP
+         PELELMEX_HOME: ${GITHUB_WORKSPACE}
+         AMREX_HYDRO_HOME: ${GITHUB_WORKSPACE}/build/AMReX-Hydro
+         SUNDIALS_HOME : ${GITHUB_WORKSPACE}/build/sundials
+      working-directory: ./Exec/RegTests/SootRadTest/
+      run: |
+        make TPL COMP=gnu USE_MPI=TRUE TINY_PROFILE=FALSE
+        make -j 2 COMP=gnu USE_MPI=TRUE TINY_PROFILE=FALSE
+    - name: Run Release
+      env:
+         PELERAD_HOME: ${GITHUB_WORKSPACE}/build/PeleRad
+      working-directory: ./Exec/RegTests/SootRadTest/
+      run: |
+        eval DATA_PATH=$PELERAD_HOME
+        mpirun -n 2 ./PeleLMeX2d.gnu.MPI.ex first-input amr.max_step=2 amr.plot_int=2 amr.check_int=2 pelerad.kppath="$DATA_PATH/data/kpDB/"
+    - name: Build Debug
+      env:
+         AMREX_HOME: ${GITHUB_WORKSPACE}/build/amrex
+         PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
+         PELERAD_HOME: ${GITHUB_WORKSPACE}/build/PeleRad
+         PELEMP_HOME: ${GITHUB_WORKSPACE}/build/PeleMP
+         PELELMEX_HOME: ${GITHUB_WORKSPACE}
+         AMREX_HYDRO_HOME: ${GITHUB_WORKSPACE}/build/AMReX-Hydro
+         SUNDIALS_HOME : ${GITHUB_WORKSPACE}/build/sundials
+      working-directory: ./Exec/RegTests/SootRadTest/
+      run: |
+        make TPL COMP=gnu USE_MPI=TRUE DEBUG=TRUE TINY_PROFILE=FALSE
+        make -j 2 COMP=gnu USE_MPI=TRUE DEBUG=TRUE TINY_PROFILE=FALSE
+    - name: Run Debug
+      env:
+         PELERAD_HOME: ${GITHUB_WORKSPACE}/build/PeleRad
+      working-directory: ./Exec/RegTests/SootRadTest/
+      run: |
+        eval DATA_PATH=$PELERAD_HOME
+        mpirun -n 2 ./PeleLMeX2d.gnu.DEBUG.MPI.ex first-input amr.max_step=2 amr.plot_int=2 amr.check_int=2 pelerad.kppath="$DATA_PATH/data/kpDB/"
 
   # Build and Run the EB_BackwardStepFlame RegTest with GNU9.3 and MPI support
   EBBFS:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,11 +96,6 @@ jobs:
     - name: Repo Dependencies
       run: |
         Utils/CloneDeps.sh
-        cd ${GITHUB_WORKSPACE}/build/amrex
-        git remote add wzhang https://github.com/WeiqunZhang/amrex.git
-        git fetch wzhang eb_robin
-        git checkout eb_robin
-        cd -
         git clone --branch main https://github.com/AMReX-Combustion/PeleRad.git build/PeleRad
     - name: Build Release
       env:

--- a/Exec/RegTests/SootRadTest/README.md
+++ b/Exec/RegTests/SootRadTest/README.md
@@ -1,4 +1,12 @@
 ## SootRadTest
 Testing of the coupling between PeleLMeX and PeleMP soot and radiation modules.
+
+For now, PeleRad must be clone separately for this test case. In a convenient
+location, run:
+
+git clone https://github.com/AMReX-Combustion/PeleRad.git
+export PELERAD_HOME=$(pwd)/PeleRad
+
 Please specify the radiation database path in the input file before running.
+
 echo "pelerad.kppath = "$PELERAD_HOME/data/kpDB/"" >> first-input

--- a/Exec/RegTests/SootRadTest/first-input
+++ b/Exec/RegTests/SootRadTest/first-input
@@ -11,7 +11,7 @@ peleLM.lo_bc = Inflow Interior Interior
 peleLM.hi_bc = Outflow Interior Interior
 
 #-------------------------AMR CONTROL----------------------------
-amr.n_cell          = 128 8 8      # Level 0 number of cells in each direction   
+amr.n_cell          = 128 8 8      # Level 0 number of cells in each direction
 amr.v               = 1                # AMR verbose
 amr.max_level       = 2                # maximum level number allowed
 amr.regrid_int      = 4                # how often to regrid
@@ -67,8 +67,8 @@ peleLM.use_typ_vals_chem = 0          # Use species/temp typical values in CVODE
 # ode.rtol = 1.0e-6                     # Relative tolerance of the chemical solve
 # ode.atol = 1.0e-5                     # Absolute tolerance factor applied on typical values
 #cvode.solve_type = GMRES
-#cvode.solve_type = denseAJ_direct     # CVODE Linear solve type (for Newton direction) 
-cvode.solve_type = magma_direct     # CVODE Linear solve type (for Newton direction) 
+cvode.solve_type = dense_direct     # CVODE Linear solve type (for Newton direction)
+#cvode.solve_type = magma_direct     # CVODE Linear solve type (for Newton direction)
 #cvode.max_order  = 4                  # CVODE max BDF order.
 #ode.atol = 1.E-12
 

--- a/Source/PeleLMeX_DeriveFunc.cpp
+++ b/Source/PeleLMeX_DeriveFunc.cpp
@@ -185,7 +185,7 @@ pelelmex_derrhomrhoy(
   AMREX_ASSERT(statefab.box().contains(bx));
   AMREX_ASSERT(derfab.nComp() >= dcomp + ncomp);
   AMREX_ASSERT(statefab.nComp() >= NUM_SPECIES + 1);
-  AMREX_ASSERT(ncomp == NUM_SPECIES);
+  AMREX_ASSERT(ncomp == 1);
   AMREX_ASSERT(!a_pelelm->m_incompressible);
   auto const in_dat = statefab.array();
   auto der = derfab.array(dcomp);


### PR DESCRIPTION
Builds and runs the SootRadTest with GNUmake in debug and release mode. Right now, the debug case fails with an out-of-bounds error. As far as I'm concerned, addressing that is the last big step before merging the radiation PR.